### PR TITLE
Add MedTile.scale-200.png

### DIFF
--- a/config.json
+++ b/config.json
@@ -133,6 +133,18 @@
       "type": "raster",
       "fileType": "source",
       "inputPath": "logo.svg",
+      "outputPath": "msix/Assets/MedTile.scale-200.png",
+      "outputFileType": "png",
+      "width": 300,
+      "height": 300,
+      "paddingPixelsWidth": 75,
+      "paddingPixelsHeight": 75,
+      "fit": "contain"
+    },
+    {
+      "type": "raster",
+      "fileType": "source",
+      "inputPath": "logo.svg",
       "outputPath": "msix/Assets/SmallTile.scale-200.png",
       "outputFileType": "png",
       "width": 142,


### PR DESCRIPTION
To resolve [bug 1674047](https://bugzilla.mozilla.org/show_bug.cgi?id=1674047) for MSiX builds, we need to ship a dedicated MedTile.scale-200.png with the corresponding paddings. This PR adds it to the config.